### PR TITLE
1 correct get client requirements

### DIFF
--- a/lowball/builtins/providers/auth_provider.py
+++ b/lowball/builtins/providers/auth_provider.py
@@ -70,7 +70,9 @@ class DefaultAuthProvider(AuthProvider):
             raise InvalidCredentialsException
 
     def get_client(self, client_id):
-        return ClientData(client_id=self.username, roles=["admin"])
+        if client_id == self.username:
+            return ClientData(client_id=self.username, roles=["admin"])
+        return None
 
     @property
     def auth_package_class(self):

--- a/lowball/models/provider_models/auth_provider.py
+++ b/lowball/models/provider_models/auth_provider.py
@@ -22,18 +22,6 @@ class AuthProvider(ABC):
         """
         pass
 
-    @abstractmethod
-    def get_client(self, client_id):
-        """Get data for a user.
-
-        
-
-        :param client_id: user to get data for
-        :type client_id: str
-        :return: ClientData  or subclass
-        """
-        pass
-
     @property
     def initialized(self):
         """Property used to determine if the authentication provider is initialized.
@@ -85,6 +73,17 @@ class AuthProvider(ABC):
         :return: AuthPackage class accepted for this auth provider
         """
         raise NotImplementedException("self_update_client_package_class")
+
+    def get_client(self, client_id):
+        """Get data for a user.
+
+
+
+        :param client_id: user to get data for
+        :type client_id: str
+        :return: ClientData  or subclass
+        """
+        raise NotImplementedException("get_client")
 
     def create_client(self, client_registration_package):
         """Create a client.

--- a/lowball/routes/builtins/auth.py
+++ b/lowball/routes/builtins/auth.py
@@ -178,7 +178,13 @@ def create_token():
         if current_app.auth_provider is None:
             raise AuthenticationNotInitializedException
 
-        target_client = current_app.auth_provider.get_client(client_id)
+        try:
+            target_client = current_app.auth_provider.get_client(client_id)
+        except NotImplementedException as err:
+            err.code = 409
+            err.description = "get_client is not implemented in this auth provider. " \
+                              "Non admin clients are unable to create tokens"
+            raise err
 
         if not target_client:
             raise NotFoundException("Client ID for requesting token not found in auth provider")

--- a/tests/lowball/builtins/providers/conftest.py
+++ b/tests/lowball/builtins/providers/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from ruamel.yaml import YAML
 
 from lowball.builtins.providers import DefaultAuthDB, DefaultAuthProvider, DefaultAuthPackage
-from lowball.models.authentication_models import Token
+from lowball.models.authentication_models import Token, ClientData
 from lowball.models.provider_models.auth_provider import AuthPackage
 import json
 
@@ -224,3 +224,22 @@ def pathlike_token(token, pathlike_token_id):
     new_token = deepcopy(token)
     new_token._token_id = pathlike_token_id
     return new_token
+
+
+@pytest.fixture(params=[
+    "admin",
+    "user",
+    "weirdo",
+    "blob",
+    1,
+    None,
+    "flop"
+])
+def get_client_expected_outcomes(request, admin_role):
+    client_id = request.param
+
+    if client_id == "admin":
+        return client_id, ClientData(client_id="admin", roles=admin_role)
+    else:
+        return client_id, None
+

--- a/tests/lowball/builtins/providers/test_auth_provider.py
+++ b/tests/lowball/builtins/providers/test_auth_provider.py
@@ -63,3 +63,15 @@ class TestDefaultAuthProvider:
 
     def test_initialized_returns_true(self, default_auth_provider):
         assert default_auth_provider.initialized
+
+    def test_get_client_returns_expected_client(self, default_auth_provider, get_client_expected_outcomes):
+
+        client_id, expected_client_data = get_client_expected_outcomes
+
+        client_data = default_auth_provider.get_client(client_id)
+
+        assert type(client_data) == type(expected_client_data)
+        if expected_client_data is not None:
+            assert isinstance(client_data, ClientData)
+            assert client_data.to_dict() == expected_client_data.to_dict()
+

--- a/tests/lowball/routes/builtins/conftest.py
+++ b/tests/lowball/routes/builtins/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from lowball.authentication import Authentication
 from lowball.builtins import DefaultAuthDB, DefaultAuthProvider
 from lowball.core import Lowball
-from lowball.exceptions import InvalidCredentialsException
+from lowball.exceptions import InvalidCredentialsException, NotImplementedException
 from lowball.models.provider_models.auth_provider import AuthPackage, AuthProvider, CreateClientPackage, \
     ClientRegistrationPackage, SelfUpdateClientPackage, UpdateClientPackage
 from lowball.models.provider_models.auth_db import AuthDatabase
@@ -945,10 +945,6 @@ class TestAuthProvider(AuthProvider):
 
         pass
 
-    def get_client(self, client_id):
-
-        pass
-
     @property
     def auth_package_class(self):
         return None
@@ -977,6 +973,11 @@ def mock_get_client_filled(monkeypatch, client_db):
         return client_db.get(client_id)
 
     monkeypatch.setattr(TestAuthProvider, "get_client", Mock(wraps=get_client))
+
+@pytest.fixture
+def mock_get_client_not_implemented(monkeypatch):
+
+    monkeypatch.setattr(TestAuthProvider, "get_client", Mock(side_effect=NotImplementedException("get_client")))
 
 @pytest.fixture
 def mock_list_clients_filled(monkeypatch, client_db):

--- a/tests/lowball/routes/builtins/test_auth.py
+++ b/tests/lowball/routes/builtins/test_auth.py
@@ -256,6 +256,22 @@ class TestCreateToken:
         assert response.status_code == 401
         assert "Current Token Has Inadequate Roles for Requested Action" in response.json["message"]
 
+    def test_create_token_fails_for_non_admin_client_when_get_client_is_not_implemented(self,
+                                                                                        normal1_token1_request_header,
+                                                                                        client_id_normal1,
+                                                                                        lowball_app_mock_providers,
+                                                                                        mock_lookup_token_filled,
+                                                                                        mock_get_client_not_implemented
+                                                                                        ):
+        response = lowball_app_mock_providers.post(self.ROUTE, headers=normal1_token1_request_header,
+                                                   json={"client_id": client_id_normal1})
+        lowball_app_mock_providers.application.auth_provider.get_client.assert_called_once_with(client_id_normal1)
+
+        print(response.json)
+        assert response.status_code == 409
+        assert "get_client is not implemented in this auth provider. Non admin clients are unable to create tokens" \
+               in response.json["message"]
+
     def test_create_token_creates_expected_tokens_for_admin_clients(self,
                                                                     lowball_app_mock_providers,
                                                                     mock_lookup_token_filled,


### PR DESCRIPTION
Removed get_client as required method for implementation, added additional tests and implementation to correct get_client in built in auth provider. Added separate output for the create_token method when requested by a non admin user. 